### PR TITLE
Fix for UTF-8-issue in Docker Containers

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -123,6 +123,7 @@ def login(data, input_url=None, password=None, verify=True,
                               r.status_code)
             sys.exit(2)
 
+        r.encoding='utf-8-sig'          
         salt = r.json()["Salt"]
         data["nonce"] = urllib.parse.unquote(r.json()["Nonce"])
         token = urllib.parse.unquote(r.cookies["xsrf-token"])


### PR DESCRIPTION
Like described in issue #21 (https://github.com/Pectojin/duplicati-client/issues/21) there is an UTF-8-issue when you are calling r.json inside a docker cointainer. 

I found a valid solution based on this article: https://www.howtosolutions.net/2019/04/python-fixing-unexpected-utf-8-bom-error-when-loading-json-data/ - easiest way ist described in step 4.

TheAmitMa commented asked to share my solution - here it is.